### PR TITLE
Load full dictionary dynamically

### DIFF
--- a/hanzi.js
+++ b/hanzi.js
@@ -1,9 +1,11 @@
-const dictionary = {
-  "你": { pinyin: "nǐ", meaning: "you" },
-  "好": { pinyin: "hǎo", meaning: "good" },
-  "永": { pinyin: "yǒng", meaning: "eternal" }
-};
-const characters = Object.keys(dictionary);
+let dictionary = {};
+const characters = ["你", "好", "永"];
+
+function loadDictionary() {
+  return fetch('hanzi-data/cedict_simplified_dict.json')
+    .then(res => res.json())
+    .then(data => { dictionary = data; });
+}
 
 function createButtons() {
   const container = document.getElementById("buttons");
@@ -26,9 +28,10 @@ function drawInput() {
 function drawCharacter(char) {
   const code = char.codePointAt(0).toString(16);
   const filename = code.padStart(4, "0"); // e.g., 6c38
-  const entry = dictionary[char] || {};
-  document.getElementById("pinyin").innerText = entry.pinyin || "";
-  document.getElementById("meaning").innerText = entry.meaning || "Meaning not found";
+  const entry = dictionary[char];
+  document.getElementById("pinyin").innerText = entry ? entry.pinyin : "";
+  const meaning = entry && entry.definitions ? entry.definitions[0] : "Meaning not found";
+  document.getElementById("meaning").innerText = meaning;
 
   fetch(`hanzi-data/${filename}.json`)
     .then(res => res.json())
@@ -55,4 +58,7 @@ function drawCharacter(char) {
     });
 }
 
-window.onload = createButtons;
+window.onload = () => {
+  loadDictionary();
+  createButtons();
+};

--- a/index.html
+++ b/index.html
@@ -21,13 +21,15 @@
   <div id="writer" style="width: 300px; height: 300px; margin: 0 auto;"></div>
 
   <script>
-    const dictionary = {
-      "你": { pinyin: "nǐ", meaning: "you" },
-      "好": { pinyin: "hǎo", meaning: "good" },
-      "永": { pinyin: "yǒng", meaning: "eternal" }
-    };
-    const characters = Object.keys(dictionary);
+    let dictionary = {};
+    const characters = ["你", "好", "永"];
     let writer;
+
+    function loadDictionary() {
+      return fetch('hanzi-data/cedict_simplified_dict.json')
+        .then(res => res.json())
+        .then(data => { dictionary = data; });
+    }
 
     function createButtons() {
       const container = document.getElementById("buttons");
@@ -48,9 +50,10 @@
     }
 
     function drawCharacter(char) {
-      const entry = dictionary[char] || {};
-      document.getElementById("pinyin").innerText = entry.pinyin || '';
-      document.getElementById("meaning").innerText = entry.meaning || 'Meaning not found';
+      const entry = dictionary[char];
+      document.getElementById("pinyin").innerText = entry ? entry.pinyin : '';
+      const meaning = entry && entry.definitions ? entry.definitions[0] : 'Meaning not found';
+      document.getElementById("meaning").innerText = meaning;
       if (writer) {
         writer.setCharacter(char);
         writer.animateCharacter();
@@ -63,7 +66,10 @@
       }
     }
 
-    window.onload = createButtons;
+    window.onload = () => {
+      loadDictionary();
+      createButtons();
+    };
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove tiny hardcoded dictionary from index and script
- fetch the `cedict_simplified_dict.json` on page load and store globally
- look up character info from the fetched dictionary
- display message when a meaning is missing

## Testing
- `node -e "const fs=require('fs'); const d=JSON.parse(fs.readFileSync('hanzi-data/cedict_simplified_dict.json')); console.log('entries', Object.keys(d).length);"`
- `node -e "const fs=require('fs'); const dict=JSON.parse(fs.readFileSync('hanzi-data/cedict_simplified_dict.json')); console.log(dict['猫']);"`

------
https://chatgpt.com/codex/tasks/task_e_685fa089c5a883249352b0c2ddc84e46