### PR TITLE
Add hanzi data extraction script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Hanzi Viewer
+
+This project displays Chinese characters and their stroke order.
+
+## Setup
+
+The repository contains a compressed archive of stroke data under `hanzi-data/hanzi-data.zip`.
+Before using the viewer for characters beyond the few sample files, extract this archive:
+
+```bash
+node extract-hanzi-data.js
+```
+
+This script unzips the JSON stroke files and renames them using the hexadecimal
+code point (e.g. `4f60.json`) that `hanzi.js` expects. The extraction only needs
+to be done once.

--- a/extract-hanzi-data.js
+++ b/extract-hanzi-data.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Unzip the stroke data archive and rename files using hex code points
+
+const fs = require('fs');
+const path = require('path');
+const {execSync} = require('child_process');
+
+const repoRoot = __dirname;
+const zipPath = path.join(repoRoot, 'hanzi-data', 'hanzi-data.zip');
+const extractDir = path.join(repoRoot, 'hanzi-data', '_extract');
+
+fs.mkdirSync(extractDir, {recursive: true});
+// extract all json files without directory structure
+execSync(`unzip -o -j "${zipPath}" '*.json' -d "${extractDir}"`, {stdio: 'inherit'});
+
+for (const file of fs.readdirSync(extractDir)) {
+  if (!file.endsWith('.json')) continue;
+  const char = path.parse(file).name;
+  if (char === '.gitkeep') continue;
+  const code = char.codePointAt(0).toString(16);
+  const destPath = path.join(repoRoot, 'hanzi-data', `${code}.json`);
+  fs.renameSync(path.join(extractDir, file), destPath);
+}
+fs.rmSync(extractDir, {recursive: true, force: true});
+console.log('Extraction complete.');


### PR DESCRIPTION
## Summary
- add setup instructions describing how to unpack stroke data
- provide `extract-hanzi-data.js` helper script for converting the zip archive

## Testing
- `node extract-hanzi-data.js` (followed by cleanup)
- `node -e "fetch('http://localhost:8000/hanzi-data/4e2d.json')..."`

------
https://chatgpt.com/codex/tasks/task_e_685fa1daae1483248296e928e981b431